### PR TITLE
Laundry list

### DIFF
--- a/addons/info.py
+++ b/addons/info.py
@@ -22,8 +22,14 @@ class Info(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         print("Addon \"{}\" loaded".format(self.__class__.__name__))
-        with open("saves/faq.json", "r") as f:
+        with open("saves/faqs/faq.json", "r") as f:
             self.faq_dict = json.load(f)
+        with open("saves/faqs/general.json", "r") as f:
+            self.general_faq_dict = json.load(f)
+        with open("saves/faqs/pksm.json", "r") as f:
+            self.pksm_faq_dict = json.load(f)
+        with open("saves/faqs/checkpoint.json", "r") as f:
+            self.checkpoint_faq_dict = json.load(f)
         with open("saves/key_inputs.json", "r") as f:
             self.key_dict = json.load(f)
 
@@ -97,16 +103,25 @@ class Info(commands.Cog):
         """Donate here"""
         await ctx.send("You can donate to FlagBrew on Patreon here: <https://www.patreon.com/FlagBrew>.\nYou can also donate to Bernardo on Patreon here: <https://www.patreon.com/BernardoGiordano>.")
 
-    async def format_faq_embed(self, ctx, faq_num, channel):
+    async def format_faq_embed(self, ctx, faq_num, channel, loaded_faq):
         embed = discord.Embed(title="Frequently Asked Questions")
         embed.title += f" #{faq_num}"
-        current_faq = self.faq_dict[faq_num - 1]
+        current_faq = loaded_faq[faq_num - 1]
         embed.add_field(name=current_faq["title"], value=current_faq["value"], inline=False)
         await channel.send(embed=embed)
 
     @commands.command()
-    async def faq(self, ctx, *, faq_item=""):
+    async def faq(self, ctx, faq_doc="", *, faq_item=""):
         """Frequently Asked Questions. Allows numeric input for specific faq."""
+        if faq_doc == "general":
+            loaded_faq = self.general_faq_dict
+        elif faq_doc == "pksm":
+            loaded_faq = self.pksm_faq_dict
+        elif faq_doc == "checkpoint":
+            loaded_faq = self.checkpoint_faq_dict
+        else:
+            loaded_faq = self.faq_dict
+            faq_item = faq_doc
         faq_item = faq_item.replace(' ', ',').split(',')
         count = 0
         dm_list = (self.bot.creator, self.bot.pie)  # Handles DMs on full command usage outside bot-channel
@@ -119,15 +134,15 @@ class Info(commands.Cog):
                     continue
             faq_num = int(faq_num)
             count += 1
-            if faq_num > 0 and faq_num < len(self.faq_dict) + 1:
-                await self.format_faq_embed(self, faq_num, ctx.channel)
+            if faq_num > 0 and faq_num < len(loaded_faq) + 1:
+                await self.format_faq_embed(self, faq_num, ctx.channel, loaded_faq)
             elif count == 1:
                 await ctx.send("Faq number {} doesn't exist.".format(faq_num))
         if count == len(faq_item):
             return
         embed = discord.Embed(title="Frequently Asked Questions")
-        for faq_arr in self.faq_dict:
-            embed.add_field(name="{}: {}".format(self.faq_dict.index(faq_arr) + 1, faq_arr["title"]), value=faq_arr["value"], inline=False)
+        for faq_arr in loaded_faq:
+            embed.add_field(name="{}: {}".format(loaded_faq.index(faq_arr) + 1, faq_arr["title"]), value=faq_arr["value"], inline=False)
         if faq_item == ['']:
             if ctx.author.id in (self.bot.creator.id, self.bot.pie.id):
                 await ctx.message.delete()

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ args = parse_cmd_arguments().parse_args()
 _test_run = args.test_run
 if _test_run:
     try:
-        os.path.isfile("saves/faq.json")
+        os.path.isfile("saves/faqs/faq.json")
         os.path.isfile("/saves/key_inputs.json")
     except:
         print('faq.json or key_inputs.json is missing')  # only visible in Travis

--- a/main.py
+++ b/main.py
@@ -234,6 +234,15 @@ async def dump_role_id(ctx):
     await asyncio.sleep(5.1)
     await ctx.message.delete()
 
+@bot.command(hidden=True)  # taken from https://github.com/appu1232/Discord-Selfbot/blob/873a2500d2c518e0d25ca5a6f67828de60fbda99/cogs/misc.py#L626
+async def ping(ctx):
+    """Get response time."""
+    msgtime = ctx.message.created_at.now()
+    await (await bot.ws.ping())
+    now = datetime.datetime.now()
+    ping = now - msgtime
+    await ctx.send('🏓 Response time is {} milliseconds.'.format(str(ping.microseconds / 1000.0)))
+
 # Execute
 print('Bot directory: ', dir_path)
 bot.run(token)

--- a/saves/faq.json
+++ b/saves/faq.json
@@ -48,8 +48,8 @@
     "value": "Sharkive has been deprecated as its functionality has been merged into [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases/latest). Use Checkpoint instead."
   },
   {
-    "title": "Where can I find the script docs?",
-    "value": "You can see what each script does [here](https://github.com/FlagBrew/PKSM-Scripts/wiki/Script-Notes)."
+    "title": "Why isn't my game showing up in Checkpoint?",
+    "value": "There could be a few reasons.\n1. Make sure you have save data in the game. Checkpoint requires a save archive to locate a game.\n2. The game might save solely in ExtData. Press `X` and make sure it's not showing up there.\n3. Reload your titles using `B`. If you loaded Checkpoint before saving in game, you'll need to do this as Checkpoint doesn't check titles at each launch."
   },
   {
     "title": "I can't access any of the channels in the Community group!",
@@ -60,7 +60,7 @@
     "value": "Backup and immediately restore PKSM's ExtData using [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases)."
   },
   {
-    "title": "Why can't I switch profiles in Checkpoint?",
-    "value": "Applet mode isn't supported. Use Atmosphere's title takeover feature (launch game holding R) instead."
+    "title": "Why am I having issues using Checkpoint under applet mode?",
+    "value": "Applet mode isn't supported, as it doesn't give enough memory. Use Atmosphere's title takeover feature (launch game holding R) instead."
   }
 ]

--- a/saves/faqs/checkpoint.json
+++ b/saves/faqs/checkpoint.json
@@ -1,0 +1,18 @@
+[
+  {
+    "title": "Can you please add a code for `x` game?",
+    "value": "Nobody on the FlagBrew team knows how to make gameshark codes, or wants to learn. All of the codes were either taken from a fort42 dump, or submitted to the repo. If you want more codes, learn how to make them yourself, or find a working one and open a pull request on the [repository](https://github.com/Flagbrew/Sharkive/pulls) to get the code added."
+  },
+  {
+    "title": "Why won't Sharkive launch?",
+    "value": "Sharkive has been deprecated as its functionality has been merged into [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases/latest). Use Checkpoint instead."
+  },
+  {
+    "title": "Why isn't my game showing up in Checkpoint?",
+    "value": "There could be a few reasons.\n1. Make sure you have save data in the game. Checkpoint requires a save archive to locate a game.\n2. The game might save solely in ExtData. Press `X` and make sure it's not showing up there.\n3. Reload your titles using `B`. If you loaded Checkpoint before saving in game, you'll need to do this as Checkpoint doesn't check titles at each launch."
+  },
+  {
+    "title": "Why am I having issues using Checkpoint under applet mode?",
+    "value": "Applet mode isn't supported, as it doesn't give enough memory. Use Atmosphere's title takeover feature (launch game holding R) instead."
+  }
+]

--- a/saves/faqs/faq.json
+++ b/saves/faqs/faq.json
@@ -1,5 +1,5 @@
 [
-   {
+  {
     "title": "When will Virtual Console games be supported?",
     "value": "Nobody on the FlagBrew team is interested in working on this. However, if you would like to work on it yourself, and the code is up to our standards, we will merge a PR."
   },
@@ -12,12 +12,12 @@
     "value": "You are likely using an outdated version of FBI. You can download the latest version [here](https://github.com/Steveice10/FBI/releases/latest).\nAny further questions about FBI should be taken to the FBI repository. **This server is not for FBI troubleshooting.**"
   },
   {
-    "title": "Can you please add a code for `x` game?",
-    "value": "Nobody on the FlagBrew team knows how to make gameshark codes, or wants to learn. All of the codes were either taken from a fort42 dump, or submitted to the repo. If you want more codes, learn how to make them yourself, or find a working one and open a pull request on the [repository](https://github.com/Flagbrew/Sharkive/pulls) to get the code added."
-  },
-  {
     "title": "I have Homebrew/*hax. Why can't I launch any Flagbrew apps?",
     "value": "FlagBrew apps *require* CFW to function. **There is no viable reason to not install CFW nowadays. There is a free method.** You can follow [this guide](https://3ds.hacks.guide) to install CFW on your 3ds. ***Versions under PKSM 7.0 are not supported and no assistance will be given with them!!!***"
+  },
+  {
+    "title": "I can't access any of the channels in the Community group!",
+    "value": "You need to toggle either 3ds updates or switch updates to access these channels now. Information on how can be found in <#278223623175798794>."
   },
   {
     "title": "My pokemon isn't legal, what do I do???",
@@ -44,20 +44,20 @@
     "value": "You can do it through a script. Fair warning that it may get your game banned however."
   },
   {
+    "title": "PKSM is erroring with Archive::init on launch, how can I fix it?",
+    "value": "Backup and immediately restore PKSM's ExtData using [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases)."
+  },
+  {
+    "title": "Can you please add a code for `x` game?",
+    "value": "Nobody on the FlagBrew team knows how to make gameshark codes, or wants to learn. All of the codes were either taken from a fort42 dump, or submitted to the repo. If you want more codes, learn how to make them yourself, or find a working one and open a pull request on the [repository](https://github.com/Flagbrew/Sharkive/pulls) to get the code added."
+  },
+  {
     "title": "Why won't Sharkive launch?",
     "value": "Sharkive has been deprecated as its functionality has been merged into [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases/latest). Use Checkpoint instead."
   },
   {
     "title": "Why isn't my game showing up in Checkpoint?",
     "value": "There could be a few reasons.\n1. Make sure you have save data in the game. Checkpoint requires a save archive to locate a game.\n2. The game might save solely in ExtData. Press `X` and make sure it's not showing up there.\n3. Reload your titles using `B`. If you loaded Checkpoint before saving in game, you'll need to do this as Checkpoint doesn't check titles at each launch."
-  },
-  {
-    "title": "I can't access any of the channels in the Community group!",
-    "value": "You need to toggle either 3ds updates or switch updates to access these channels now. Information on how can be found in <#278223623175798794>."
-  },
-  {
-    "title": "PKSM is erroring with Archive::init on launch, how can I fix it?",
-    "value": "Backup and immediately restore PKSM's ExtData using [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases)."
   },
   {
     "title": "Why am I having issues using Checkpoint under applet mode?",

--- a/saves/faqs/general.json
+++ b/saves/faqs/general.json
@@ -1,0 +1,22 @@
+[
+  {
+    "title": "When will Virtual Console games be supported?",
+    "value": "Nobody on the FlagBrew team is interested in working on this. However, if you would like to work on it yourself, and the code is up to our standards, we will merge a PR."
+  },
+  {
+    "title": "Why do I have to wait so long for new releases?",
+    "value": "Because you think you're entitled to everything."
+  },
+  {
+    "title": "Why can't I scan this QR code?",
+    "value": "You are likely using an outdated version of FBI. You can download the latest version [here](https://github.com/Steveice10/FBI/releases/latest).\nAny further questions about FBI should be taken to the FBI repository. **This server is not for FBI troubleshooting.**"
+  },
+  {
+    "title": "I have Homebrew/*hax. Why can't I launch any Flagbrew apps?",
+    "value": "FlagBrew apps *require* CFW to function. **There is no viable reason to not install CFW nowadays. There is a free method.** You can follow [this guide](https://3ds.hacks.guide) to install CFW on your 3ds. ***Versions under PKSM 7.0 are not supported and no assistance will be given with them!!!***"
+  },
+  {
+    "title": "I can't access any of the channels in the Community group!",
+    "value": "You need to toggle either 3ds updates or switch updates to access these channels now. Information on how can be found in <#278223623175798794>."
+  }
+]

--- a/saves/faqs/pksm.json
+++ b/saves/faqs/pksm.json
@@ -1,0 +1,30 @@
+[
+  {
+    "title": "My pokemon isn't legal, what do I do???",
+    "value": "The met location is incorrect. From the **edit pokemon** screen, go to the **misc** screen. Then click on **met location**. After, just select a legal met location from the list.\nYou'll need to find that using something like [serebii](https://serebii.net), or an in-game pokedex.\nNote: There may be other issues with the legality of your pokemon. Double check moves, level, etc., or use the legality checker in the same **misc** screen."
+  },
+  {
+    "title": "Can we get legality checking please?",
+    "value": "Believe it or not, you can! Go to the **edit pokemon** screen, then go to the **misc** screen. Click on the wireless icon. Congrats, you've accessed the legality checker.\nPlease note: the legality checker requires a network connection. It cannot be handled on-3ds as it would destroy the 3ds."
+  },
+  {
+    "title": "When are we getting PKSM on Switch?",
+    "value": "You can access LGPE saves by bridging PKSM on 3DS to Checkpoint on Switch. This is the best you'll get for now, possibly ever if you annoy Bernardo."
+  },
+  {
+    "title": "When are we getting Sword and Shield support?",
+    "value": "Never :)"
+  },
+  {
+    "title": "My DeSmuME save is messed up and I can't load it, help!!!",
+    "value": "If this save came from DeSmuME, then it likely has an extra 122 bytes at the end of it. Back up your file, then delete those last 122 bytes using a hex editor."
+  },
+  {
+    "title": "Can we get trainer data editing?",
+    "value": "You can do it through a script. Fair warning that it may get your game banned however."
+  },
+  {
+    "title": "PKSM is erroring with Archive::init on launch, how can I fix it?",
+    "value": "Backup and immediately restore PKSM's ExtData using [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases)."
+  }
+]


### PR DESCRIPTION
- Ping command (_finally_)
- Reaction voting for use in #suggestions. ✅ upticks, ❌  downticks, total is compiled between the two counts. If total >= 3, pins the message. If that number falls below 3, it unpins. Will change amount if necessary. Note: currently there is nothing in place to prevent users from doing both. We'll go on the honor system for now, and I'll change it if necessary.
- If anyone with the FlagBrew Team role reacts to the idea with 🆒, it will unpin the message and prevent it from being pinned again via reactions. this is best used for implemented ideas, but can also be used for repeat ideas.
- The faq command has changed. A lot.
- Faq can now take three inputs before a number - `general`, `pksm`, or `checkpoint`. If a number is given instead, it'll default to the item at that number in the full list.
- Each input pulls from its own file containing items relevant to that category. No number will post the full category contents, same as faq with no input.
- The full list is now ordered to match the order the inputs are listed. That is to say, all the general items, then all the pksm items, then all the checkpoint items.
- The script doc faq has been replaced with a faq concerning titles in checkpoint.
- The applet mode faq has been retitled to more obviously apply in more situations.