### PR TITLE
Add cmd line + env args support

### DIFF
--- a/addons/events.py
+++ b/addons/events.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import discord
-import requests
 import secrets
 import qrcode
 import io
@@ -154,7 +153,7 @@ class Events(commands.Cog):
                            " have all expired. If you do end up renewing your subscription at a later date, you will recieve a new token.")
                 url = "https://flagbrew.org/patron/remove"
                 f = None
-            requests.post(url, data=data)
+            await self.bot.session.post(url=url, data=data)
             try:
                 await before.send(message, file=f)
             except discord.Forbidden:

--- a/addons/info.py
+++ b/addons/info.py
@@ -174,7 +174,7 @@ class Info(commands.Cog):
                     return await ctx.author.send(embed=embed)
                 except discord.Forbidden:
                     pass  # Bot blocked, or api bug
-            elif ctx.channel not in (self.bot.bot_channel, self.bot.testing_channel) and not ctx.guild.id == 378420595190267915:
+            elif ctx.channel not in (self.bot.bot_channel, self.bot.testing_channel, self.bot.bot_channel2) and not ctx.guild.id == 378420595190267915:
                 for user in usage_dm:
                     try:
                         await user.send("Full faq command was attempted to be used in {} by {}\n\nHyperlink to command invoke: {}".format(ctx.channel.mention, ctx.author, ctx.message.jump_url))

--- a/config.py.sample
+++ b/config.py.sample
@@ -10,4 +10,3 @@ db_address = ""  # MongoDB database address as string
 api_url = ""  # API URL as string
 sprite_url = ""  # Sprite URL as string
 flagbrew_url = ""  # FlagBrew URL as string
-localhost_port = ""

--- a/main.py
+++ b/main.py
@@ -33,7 +33,6 @@ def parse_cmd_arguments():  # travis handler, taken from https://github.com/appu
                         help="Allows using args")
     return parser
 argpar, unknown = parse_cmd_arguments().parse_known_args()
-print(unknown)
 _test_run = argpar.test_run
 if _test_run:
     try:
@@ -59,6 +58,7 @@ if not is_using_args:  # handles pulling the config/args needed for creating the
     prefix = config.prefix
     token = config.token
     default_activity = discord.Activity(name=config.default_activity, type=discord.ActivityType.watching)
+    prefix = prefix.replace(" ", "").split(",")
 else:
     token, prefix = args[0:2]
     default_activity = discord.Activity(name=args[2], type=discord.ActivityType.watching)


### PR DESCRIPTION
Command Line:
```
python main.py -cmd "token" "prefix_a, prefix_b" "default_activity" "is_mongo" "api_url" "flagbrew_url" "sprite_url" "db_address" "secret" "github_user" "github_pass" "is_beta"
```

Environment:
```
TOKEN, PREFIX, DEF_ACT, IS_MONGODB, API_URL, FLAGBREW_URL, SPRITE_URL, DB_ADDRESS, SECRET, GIT_USER, GIT_PASS, IS_BETA
```
trigger with cmd line arg of `-env`