### PR TITLE
Move spam limiting to a decorator, extend to more commands

### DIFF
--- a/addons/info.py
+++ b/addons/info.py
@@ -7,7 +7,7 @@ import qrcode
 import io
 import json
 import math
-from addons.helper import faq_decorator, restricted_to_bot
+from addons.helper import faq_decorator, restricted_to_bot, spam_limiter
 from discord.ext import commands
 
 desc_temp = "You can get the latest release of {}."
@@ -130,6 +130,7 @@ class Info(commands.Cog):
     ]
 
     @commands.command(aliases=faq_aliases)
+    @spam_limiter
     @faq_decorator
     async def faq(self, ctx, faq_doc="", *, faq_item=""):
         """Frequently Asked Questions. Allows numeric input for specific faq, or multiple numbers in a row for multiple at a time.
@@ -193,20 +194,9 @@ class Info(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
+    @spam_limiter
     async def question(self, ctx):
         """Reminder for those who won't just ask their question"""
-        count = 0
-        async for message in ctx.channel.history(limit=10):
-            if message.content.startswith(self.bot.command_prefix[0] + "question") and (len(message.mentions) > 0 or message.reference is not None):
-                if len(message.mentions) == 0:
-                    msg_ref_auth = message.reference.resolved.author
-                else:
-                    msg_ref_auth = None
-                if not ctx.author in message.mentions and not ctx.author == msg_ref_auth:
-                    break
-                elif count > 0:
-                    return await ctx.send("{} read the goddamned message I sent, instead of just using the command again and spamming. If you ignore the contents of *this* message, you will be warned.".format(ctx.author.mention))
-            count += 1
         await ctx.send("Reminder: if you would like someone to help you, please be as descriptive as possible, of your situation, things you have done, "
                        "as little as they may seem, as well as assisting materials. Asking to ask wont expedite your process, and may delay assistance. "
                        "***WE ARE NOT PSYCHIC.***")
@@ -328,6 +318,7 @@ class Info(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command(aliases=['dg'])
+    @spam_limiter
     async def downgrade(self, ctx):
         """Don't. Fucking. Downgrade."""
         embed = discord.Embed(title="Should you downgrade?")
@@ -336,6 +327,7 @@ class Info(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command(aliases=['es'])
+    @spam_limiter
     async def extrasaves(self, ctx):
         """Extrasaves info"""
         embed = discord.Embed(title="How do I access my external saves?")
@@ -345,6 +337,7 @@ class Info(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command(aliases=["tid"])
+    @spam_limiter
     async def titleid(self, ctx):
         """Title ID adding info"""
         embed = discord.Embed(title="How do I access my GBA games?")

--- a/addons/info.py
+++ b/addons/info.py
@@ -59,6 +59,8 @@ class Info(commands.Cog):
             embed.set_thumbnail(url=current_faq["thumbnail"])
         if "image" in current_faq.keys():
             embed.set_image(url=current_faq["image"])
+        if "footer" in current_faq.keys():
+            embed.set_footer(text=current_faq["footer"])
         await channel.send(embed=embed)
 
     @commands.command(aliases=["releases", "latest"])

--- a/saves/faqs/general.json
+++ b/saves/faqs/general.json
@@ -13,6 +13,7 @@
     },
     {
         "title": "I can't access any of the channels in the Community group!",
-        "value": "You need to toggle either the `3ds Updates` or `Switch Updates` roles to access these channels. Information on how to toggle these can be found in <#278223623175798794>."
+        "value": "You need to toggle either the `3ds Updates` or `Switch Updates` roles to access these channels. Information on how to toggle these can be found in <#278223623175798794>.",
+        "footer": "Please note: DMing users asking how to access the assistance channels will lead to you receiving two warns."
     }
 ]


### PR DESCRIPTION
Newly limited commands:
- faq
- downgrade
- extrasaves
- titleid

Uses the same logic as `question`, catching on both replies and mentions for the original invoke, checking back 10 messages.