### PR TITLE
Add attachments to kickban, mute, and warn messages to users, add resolution markers to crash reports

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -629,8 +629,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2018  GriffinG1
+    FlagBrew's discord server moderation + utility bot
+    Copyright (C) 2018-2021 GriffinG1
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published

--- a/addons/events.py
+++ b/addons/events.py
@@ -31,25 +31,6 @@ class Events(commands.Cog):
                 await guild.leave()
 
     @commands.Cog.listener()
-    async def on_member_ban(self, guild, user):
-        try:
-            async for ban in guild.audit_logs(limit=20, action=discord.AuditLogAction.ban):  # 20 to handle multiple staff bans in quick succession
-                if ban.target == user:
-                    if ban.reason:
-                        reason = ban.reason
-                    else:
-                        reason = "No reason was given. Please do that in the future!"
-                    admin = ban.user
-                    break
-                else:
-                    return
-            embed = discord.Embed(title=f"{user} banned")
-            embed.description = f"{user} was banned by {admin} for:\n\n{reason}"
-            await self.bot.logs_channel.send(embed=embed)
-        except discord.Forbidden:
-            pass  # beta bot can't log
-
-    @commands.Cog.listener()
     async def on_member_join(self, member):
         try:
             mute_exp = self.bot.mutes_dict[str(member.id)]

--- a/addons/helper.py
+++ b/addons/helper.py
@@ -44,7 +44,8 @@ def restricted_to_bot(func):
         if ctx.author in (func_self.bot.allen, func_self.bot.creator, func_self.bot.pie):
             pass
         elif not ctx.channel in (func_self.bot.bot_channel, func_self.bot.bot_channel2) and ctx.guild.id == 278222834633801728:
-            return await ctx.send(f"This command is restricted to {func_self.bot.bot_channel.mention}.")
+            await ctx.message.delete()
+            return await ctx.send(f"{ctx.author.mention} This command is restricted to {func_self.bot.bot_channel.mention}.")
         await func(*args, **kwargs)
     return wrapper
 

--- a/addons/meta.py
+++ b/addons/meta.py
@@ -94,6 +94,24 @@ class Meta(commands.Cog, command_attrs=dict(hidden=True)):
         await ctx.me.edit(nick=nick)
         await ctx.send(f"Successfully changed my nickname to: `{nick}`")
 
+    @commands.command(name="license")
+    async def flagbot_license(self, ctx):
+        embed = discord.Embed(title="FlagBot's License")
+        embed.description = ("FlagBrew's discord server moderation + utility bot"
+                            "\nCopyright (C) **2018-2021** | **GriffinG1**"
+                            "\n\nThis program is free software: you can redistribute it and/or modify\n"
+                            "it under the terms of the GNU Affero General Public License as published\n"
+                            "by the Free Software Foundation, either version 3 of the License, or\n"
+                            "(at your option) any later version.\n"
+                            "This program is distributed in the hope that it will be useful,\n"
+                            "but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+                            "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n"
+                            "See the GNU Affero General Public License for more details.\n"
+                            "A copy of the GNU Affero General Public License is available "
+                            "[in the program's repository](https://github.com/GriffinG1/FlagBot/blob/master/LICENSE)."
+                            )
+        await ctx.send(embed=embed)
+
 
 def setup(bot):
     bot.add_cog(Meta(bot))

--- a/addons/mod.py
+++ b/addons/mod.py
@@ -100,7 +100,7 @@ class Moderation(commands.Cog):
             embed = discord.Embed(title=f"{user} banned")
             embed.description = f"{user} was banned by {admin} for:\n\n{reason}"
             if user.id in self.ban_attch_dict.keys():
-                img = discord.File(self.ban_attch_dict[str(user.id)], 'ban_image.png')
+                img = discord.File(self.ban_attch_dict.pop(str(user.id)), 'ban_image.png')
                 embed.set_thumbnail(url="attachment://ban_image.png")
             else:
                 img = None

--- a/addons/mod.py
+++ b/addons/mod.py
@@ -76,6 +76,25 @@ class Moderation(commands.Cog):
             embed.set_image(url="https://fm1337.com/static/img/giratina-banned.png")
         await ctx.send(f"Successfully banned user {member}!", embed=embed)
 
+    @commands.Cog.listener()
+    async def on_member_ban(self, guild, user):
+        try:
+            async for ban in guild.audit_logs(limit=20, action=discord.AuditLogAction.ban):  # 20 to handle multiple staff bans in quick succession
+                if ban.target == user:
+                    if ban.reason:
+                        reason = ban.reason
+                    else:
+                        reason = "No reason was given. Please do that in the future!"
+                    admin = ban.user
+                    break
+                else:
+                    return
+            embed = discord.Embed(title=f"{user} banned")
+            embed.description = f"{user} was banned by {admin} for:\n\n{reason}"
+            await self.bot.logs_channel.send(embed=embed)
+        except discord.Forbidden:
+            pass  # beta bot can't log
+
     @commands.command(pass_context=True)
     @commands.has_any_role("Discord Moderator")
     async def kick(self, ctx, member: discord.Member, *, reason="No reason was given."):

--- a/addons/mod.py
+++ b/addons/mod.py
@@ -114,10 +114,6 @@ class Moderation(commands.Cog):
             embed = discord.Embed(title=f"{member} kicked")
             embed.description = f"{member} was kicked by {ctx.message.author} for:\n\n{reason}"
             try:
-                await self.bot.logs_channel.send(embed=embed)
-            except discord.Forbidden:
-                pass  # beta bot can't log
-            try:
                 if has_attch:
                     img_bytes = await ctx.message.attachments[0].read()
                     img = discord.File(io.BytesIO(img_bytes), 'kick_image.png')
@@ -125,8 +121,13 @@ class Moderation(commands.Cog):
                     embed.set_thumbnail(url="attachment://kick_image.png")
                 else:
                     await member.send(f"You were kicked from FlagBrew for:\n\n`{reason}`\n\nIf you believe this to be in error, you can rejoin here: https://discord.gg/bGKEyfY")
+                    img = None
             except discord.Forbidden:
                 pass  # bot blocked or not accepting DMs
+            try:
+                await self.bot.logs_channel.send(embed=embed, file=img)
+            except discord.Forbidden:
+                pass  # beta bot can't log
             if len(reason) > 512:
                 await member.kick(reason=f"Failed to log reason, as reason length was {len(reason)}. Please check bot logs.")
             else:
@@ -188,10 +189,11 @@ class Moderation(commands.Cog):
                 embed.set_thumbnail(url="attachment://mute_image.png")
             else:
                 await member.send(f"You were muted on FlagBrew for:\n\n`{reason}`")
+                img = None
         except discord.Forbidden:
             pass  # blocked DMs
         try:
-            await self.bot.logs_channel.send(embed=embed)
+            await self.bot.logs_channel.send(embed=embed, file=img)
         except discord.Forbidden:
             pass  # beta can't log
         await ctx.send(f"Successfully muted {member}!")
@@ -259,13 +261,14 @@ class Moderation(commands.Cog):
                 embed.set_thumbnail(url="attachment://mute_image.png")
             else:
                 await member.send(f"You have been muted on {ctx.guild} for\n\n`{reason}`\n\nYou will be unmuted on {end_str}.")
+                img = None
         except discord.Forbidden:
             pass  # blocked DMs
         self.bot.mutes_dict[str(member.id)] = end_str
         with open("saves/mutes.json", "w") as f:
             json.dump(self.bot.mutes_dict, f, indent=4)
         try:
-            await self.bot.logs_channel.send(embed=embed)
+            await self.bot.logs_channel.send(embed=embed, file=img)
         except discord.Forbidden:
             pass  # beta can't log
         await ctx.send(f"Successfully muted {member} until `{end_str}` UTC!")

--- a/addons/mod.py
+++ b/addons/mod.py
@@ -120,8 +120,9 @@ class Moderation(commands.Cog):
             try:
                 if has_attch:
                     img_bytes = await ctx.message.attachments[0].read()
-                    img = io.BytesIO(img_bytes)
-                    await member.send(f"You were kicked from FlagBrew for:\n\n`{reason}`\n\nIf you believe this to be in error, you can rejoin here: https://discord.gg/bGKEyfY", file=discord.File(img))
+                    img = discord.File(io.BytesIO(img_bytes), 'kick_image.png')
+                    await member.send(f"You were kicked from FlagBrew for:\n\n`{reason}`\n\nIf you believe this to be in error, you can rejoin here: https://discord.gg/bGKEyfY", file=img)
+                    embed.set_thumbnail(url="attachment://kick_image.png")
                 else:
                     await member.send(f"You were kicked from FlagBrew for:\n\n`{reason}`\n\nIf you believe this to be in error, you can rejoin here: https://discord.gg/bGKEyfY")
             except discord.Forbidden:
@@ -182,8 +183,9 @@ class Moderation(commands.Cog):
         try:
             if has_attch:
                 img_bytes = await ctx.message.attachments[0].read()
-                img = io.BytesIO(img_bytes)
-                await member.send(f"You were muted on FlagBrew for:\n\n`{reason}`", file=discord.File(img))
+                img = discord.File(io.BytesIO(img_bytes), 'mute_image.png')
+                await member.send(f"You were muted on FlagBrew for:\n\n`{reason}`", file=img)
+                embed.set_thumbnail(url="attachment://mute_image.png")
             else:
                 await member.send(f"You were muted on FlagBrew for:\n\n`{reason}`")
         except discord.Forbidden:
@@ -247,11 +249,14 @@ class Moderation(commands.Cog):
         end = curr_time + diff
         end_str = end.strftime("%Y-%m-%d %H:%M:%S")
         await member.add_roles(self.bot.mute_role)
+        embed = discord.Embed(title=f"{member} ({member.id}) timemuted")
+        embed.description = f"{member} timemuted by {ctx.message.author} until {end_str} UTC for:\n\n{reason}"
         try:
             if has_attch:
                 img_bytes = await ctx.message.attachments[0].read()
-                img = io.BytesIO(img_bytes)
-                await member.send(f"You have been muted on {ctx.guild} for\n\n`{reason}`\n\nYou will be unmuted on {end_str}.", file=discord.File(img))
+                img = discord.File(io.BytesIO(img_bytes), 'mute_image.png')
+                await member.send(f"You have been muted on {ctx.guild} for\n\n`{reason}`\n\nYou will be unmuted on {end_str}.", file=img)
+                embed.set_thumbnail(url="attachment://mute_image.png")
             else:
                 await member.send(f"You have been muted on {ctx.guild} for\n\n`{reason}`\n\nYou will be unmuted on {end_str}.")
         except discord.Forbidden:
@@ -259,8 +264,6 @@ class Moderation(commands.Cog):
         self.bot.mutes_dict[str(member.id)] = end_str
         with open("saves/mutes.json", "w") as f:
             json.dump(self.bot.mutes_dict, f, indent=4)
-        embed = discord.Embed(title=f"{member} ({member.id}) timemuted")
-        embed.description = f"{member} timemuted by {ctx.message.author} until {end_str} UTC for:\n\n{reason}"
         try:
             await self.bot.logs_channel.send(embed=embed)
         except discord.Forbidden:

--- a/addons/warns.py
+++ b/addons/warns.py
@@ -1,6 +1,7 @@
 import discord
 import json
 import random
+import io
 from datetime import datetime
 from discord.ext import commands
 from addons.helper import restricted_to_bot
@@ -17,6 +18,7 @@ class Warning(commands.Cog):
     @commands.has_any_role("Discord Moderator")
     async def warn(self, ctx, target: discord.Member, *, reason="No reason was given"):
         """Warns a user. Kicks at 3 and 4 warnings, bans at 5"""
+        has_attch = bool(ctx.message.attachments)
         try:
             self.bot.warns_dict[str(target.id)]
         except KeyError:
@@ -43,7 +45,12 @@ class Warning(commands.Cog):
         embed = discord.Embed(title=f"{target} warned")
         embed.description = f"{target} | {target.id} was warned in {ctx.channel.mention} by {ctx.author} for `{reason}`. This is warn #{len(warns)}. {log_msg}"
         try:
-            await target.send(dm_msg)
+            if has_attch:
+                img_bytes = await ctx.message.attachments[0].read()
+                img = io.BytesIO(img_bytes)
+                await target.send(dm_msg, file=discord.File(img))
+            else:
+                await target.send(dm_msg)
         except discord.Forbidden:
             embed.description += "\n**Could not DM user.**"
         if self.bot.is_mongodb:

--- a/addons/warns.py
+++ b/addons/warns.py
@@ -47,8 +47,9 @@ class Warning(commands.Cog):
         try:
             if has_attch:
                 img_bytes = await ctx.message.attachments[0].read()
-                img = io.BytesIO(img_bytes)
-                await target.send(dm_msg, file=discord.File(img))
+                img = discord.File(io.BytesIO(img_bytes), 'warn_image.png')
+                await target.send(dm_msg, file=img)
+                embed.set_thumbnail(url="attachment://warn_image.png")
             else:
                 await target.send(dm_msg)
         except discord.Forbidden:

--- a/addons/warns.py
+++ b/addons/warns.py
@@ -52,6 +52,7 @@ class Warning(commands.Cog):
                 embed.set_thumbnail(url="attachment://warn_image.png")
             else:
                 await target.send(dm_msg)
+                img = None
         except discord.Forbidden:
             embed.description += "\n**Could not DM user.**"
         if self.bot.is_mongodb:
@@ -80,7 +81,7 @@ class Warning(commands.Cog):
         elif len(warns) >= 3:
             await target.kick(reason=f"Warn #{len(warns)}")
         try:
-            await self.bot.logs_channel.send(embed=embed)
+            await self.bot.logs_channel.send(embed=embed, file=img)
         except discord.Forbidden:
             pass  # beta can't log
         if len(warns) >= 5:


### PR DESCRIPTION
Making this a draft review for now, until @FM1337 gets back to me on if he wants me to add the images to logging for kick, mute, and warn.

If so, I will also open a help wanted issue on my repo for anyone that wants to try and make a clean method for adding it to ban logs. Due to how I have them set up (running off of a listener) with the reason being audit log scraped, I can't think of a clean method to handle this (unless I set up a cog-wide dict that ban adds to, then the listener can check for the attch on there by uid + clear it from the dict... hmm...)