### PR TITLE
Clean up the guide command, update rules FAQ for category changes, command concerning locklair vids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 language: python
 python:
-  - "3.7"
+  - "3.10"
 script: # stolen from https://github.com/appu1232/Discord-Selfbot/blob/master/.travis.yml
   - python -m compileall ./main.py
   - python -m compileall ./addons

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 language: python
 python:
-  - "3.10"
+  - "3.9"
 script: # stolen from https://github.com/appu1232/Discord-Selfbot/blob/master/.travis.yml
   - python -m compileall ./main.py
   - python -m compileall ./addons

--- a/addons/info.py
+++ b/addons/info.py
@@ -464,6 +464,15 @@ class Info(commands.Cog):
         embed.set_footer(text="Info taken and modified from thecommondude#8240's pin in PKHeX Development Project #general-pkhex")
         await ctx.send(embed=embed)
 
+    @commands.command()
+    async def locklair(self, ctx):
+        """This person should not be allowed to make youtube videos."""
+        embed = discord.Embed(title="So, you're following a video by Blaine Locklair to hack your 3DS")
+        embed.add_field(name="What's the issue with video guides, and Blaine's specifically?", value="Video guides in general get outdated extremely quickly. You should only be following [this guide](https://3ds.hacks.guide) if you're hacking your 3DS, or [this guide](https://nh-server.github.io/switch-guide/) if you're hacking your Switch.\nBlaine in particular tends to just reupload the same video guide over and over again with no real change, leading to issues.", inline=False)
+        embed.add_field(name="I've followed their 3DS guide this far, what should I do now?", value="Continue on from [this page](https://3ds.hacks.guide/finalizing-setup) of the 3ds guide linked above. That will run you through getting all the files you need from the correct links.", inline=False)
+        embed.add_field(name="Well why can't I find the Checkpoint.cia file?", value="Checkpoint 3.8.0 is unstable on 3DS currently. As such, the CIA file for it was removed from the release. Please use [3.7.4](https://github.com/FlagBrew/Checkpoint/tag/v3.7.4).", inline=False)
+        await ctx.send(embed=embed)
+
 
 def setup(bot):
     bot.add_cog(Info(bot))

--- a/addons/info.py
+++ b/addons/info.py
@@ -271,18 +271,18 @@ class Info(commands.Cog):
 
     @commands.command()
     async def guide(self, ctx, option=""):
-        """Links to 3ds & switch guides. Each can be given for specific. Defaults to 3ds in any channel that starts with pksm"""
-        embed = discord.Embed(description="")
+        """Links to 3ds & switch guides. Each can be given for specific"""
+        embed = discord.Embed(title="Console Hacking Guides", description="")
         ds, switch = (True,) * 2
         if option.lower() == "switch":
             ds = False
-        elif ctx.channel.name.startswith("pksm") or option.lower() == "3ds":
+        elif option.lower() == "3ds":
             switch = False
-            ds = True
         if ds:
             embed.description += "You can use [this guide](https://3ds.hacks.guide) to hack your 3ds.\n"
         if switch:
             embed.description += "You can use [this guide](https://nh-server.github.io/switch-guide/) to hack your switch."
+        embed.set_thumbnail(url='https://avatars.githubusercontent.com/u/45153157')
         await ctx.send(embed=embed)
 
     def get_keys(self, hexval):  # thanks to architdate for the code

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,4 +1,5 @@
 from discord.ext import commands
 
+
 class PKHeXMissingArgs(commands.CommandError):
     pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ qrcode[pil]
 pymongo
 validators
 psutil
+importlib_metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-importlib_metadata
 discord.py>=1.6.0
 qrcode[pil]
 pymongo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
+importlib_metadata
 discord.py>=1.6.0
 qrcode[pil]
 pymongo
 validators
 psutil
-importlib_metadata

--- a/saves/faqs/general.json
+++ b/saves/faqs/general.json
@@ -36,7 +36,7 @@
         "fields": [
             {
                 "inline": false,
-                "name": "I can't access any of the channels in the Community group!",
+                "name": "I can't access any of the channels in the Community, Checkpoint, or PKSM groups!",
                 "value": "You need to toggle either the `3ds Updates` or `Switch Updates` roles to access these channels. Information on how to toggle these can be found in <#278223623175798794>."
             }
         ],


### PR DESCRIPTION
Guide command has a thumbnail now, woo! Looks a lot nicer imo

`.locklair` should be used for ppl suspected of coming from a Blaire Locklair video due to his laziness w/ those videos.