### PR TITLE
Add create_save_path (csp), auto-adds `bot submission` label for `rc` submissions, misc cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ saves/new_layout.json
 saves/banned_phrases.json
 saves/persistent_vars.json
 saves/role_mentions.json
+saves/xmls/*

--- a/addons/events.py
+++ b/addons/events.py
@@ -35,8 +35,8 @@ class Events(commands.Cog):
 
     @commands.Cog.listener()
     async def on_member_join(self, member):
-        # if self.bot.is_beta:
-        #     return
+        if self.bot.is_beta:
+            return
         try:
             mute_exp = self.bot.mutes_dict[str(member.id)]
         except KeyError:

--- a/addons/info.py
+++ b/addons/info.py
@@ -328,23 +328,6 @@ class Info(commands.Cog):
             decval -= 2**key_index
         return final_indices
 
-    @commands.command()
-    @helper.restricted_to_bot
-    async def cheatkeys(self, ctx, *, key):
-        """Byte decoder for sharkive codes. Input should be the second half of the line starting with DD000000"""
-        key = key.replace(' ', '').replace('DD000000', '')
-        if len(key) != 8:
-            return await ctx.send("That isn't a valid key!")
-        indexes = self.get_keys(key)
-        if indexes == 400:
-            return await ctx.send("That isn't a valid key!")
-        embed = discord.Embed(title=f"Matching inputs for `{key}`")
-        if len(indexes["3ds"]) > 0:
-            embed.add_field(name="3DS inputs", value='`' + '` + `'.join(indexes["3ds"]) + '`')
-        if len(indexes["switch"]) > 0:
-            embed.add_field(name="Switch inputs", value='`' + '` + `'.join(indexes["switch"]) + '`', inline=False)
-        await ctx.send(embed=embed)
-
     @commands.command(aliases=['dg'])
     @helper.spam_limiter
     async def downgrade(self, ctx):

--- a/addons/info.py
+++ b/addons/info.py
@@ -6,7 +6,6 @@ import discord
 import qrcode
 import io
 import json
-import math
 import addons.helper as helper
 from discord.ext import commands
 from datetime import datetime

--- a/addons/info.py
+++ b/addons/info.py
@@ -308,26 +308,6 @@ class Info(commands.Cog):
         embed.set_thumbnail(url='https://avatars.githubusercontent.com/u/45153157')
         await ctx.send(embed=embed)
 
-    def get_keys(self, hexval):  # thanks to architdate for the code
-        final_indices = {'3ds': [], 'switch': []}
-        try:
-            decval = int(hexval, 16)
-        except ValueError:
-            return 400
-        while decval != 0:
-            key_index = math.floor(math.log(decval, 2))
-            try:
-                key_3ds = helper.key_inputs.get(hex(2**key_index))[0]
-                if key_3ds != "None":
-                    final_indices['3ds'].append(key_3ds)
-                key_switch = helper.key_inputs.get(hex(2**key_index))[1]
-                if key_switch != "None" and hexval.replace('0x', '')[0] == "8":
-                    final_indices['switch'].append(key_switch)
-            except IndexError:
-                return 400
-            decval -= 2**key_index
-        return final_indices
-
     @commands.command(aliases=['dg'])
     @helper.spam_limiter
     async def downgrade(self, ctx):

--- a/addons/utility.py
+++ b/addons/utility.py
@@ -11,7 +11,8 @@ import qrcode
 import io
 import hashlib
 import validators
-from addons.helper import restricted_to_bot
+import math
+import addons.helper as helper
 
 
 class Utility(commands.Cog):
@@ -43,7 +44,7 @@ class Utility(commands.Cog):
             return True
 
     @commands.command()
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def togglerole(self, ctx, role):
         """Allows user to toggle update roles. Available roles: see #welcome-and-rules, as well as 'bot'"""
         user = ctx.message.author
@@ -58,7 +59,7 @@ class Utility(commands.Cog):
         await ctx.send(user.mention + ' ' + info_string)
 
     @commands.command(hidden=True)
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def masstoggle(self, ctx):
         """Allows a user to toggle both console update roles"""
         toggle_roles = [
@@ -106,7 +107,7 @@ class Utility(commands.Cog):
 
     @secure_role_mention.command(name="list")
     @commands.has_any_role("Discord Moderator", "FlagBrew Team")
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def secure_role_message_list(self, ctx):
         """Lists all available roles for secure_role_mention"""
         embed = discord.Embed(title="Mentionable Roles")
@@ -117,7 +118,7 @@ class Utility(commands.Cog):
 
     @secure_role_mention.command(name="add")
     @commands.has_any_role("Discord Moderator", "FlagBrew Team")
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def secure_role_message_add(self, ctx, role_name, role: discord.Role):
         """Allows adding a role to the dict for secure_role_mention. 'role_name' should be the name that will be used for srm invoking, 'role' should be the ID or a mention of the pinged role"""
         try:
@@ -135,7 +136,7 @@ class Utility(commands.Cog):
 
     @secure_role_mention.command(name="remove")
     @commands.has_any_role("Discord Moderator", "FlagBrew Team")
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def secure_role_mention_remove(self, ctx, role_name):
         """Allows removing a role from the dict for secure_role_mention. 'role_name' should be the name that will be used for srm invoking"""
         try:
@@ -164,7 +165,7 @@ class Utility(commands.Cog):
 
     @commands.command()
     @commands.has_any_role("Discord Moderator", "FlagBrew Team")
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def regen_token(self, ctx, user: discord.Member):
         """Regenerates a patron's token"""
         if not self.bot.is_mongodb:
@@ -192,7 +193,7 @@ class Utility(commands.Cog):
 
     @commands.command()
     @commands.has_any_role("Discord Moderator", "FlagBrew Team")
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def delete_token(self, ctx, user: discord.Member, *, reason="No reason provided"):
         """Deletes a patron's token"""
         if not self.bot.is_mongodb:
@@ -207,7 +208,7 @@ class Utility(commands.Cog):
 
     @commands.command()
     @commands.has_any_role("Discord Moderator", "FlagBrew Team")
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def generate_token(self, ctx, user: discord.Member):
         """Generates a patron token. If user already in system, use regen_token"""
         if not self.bot.is_mongodb:
@@ -234,7 +235,7 @@ class Utility(commands.Cog):
         await ctx.send(f"Token for user {user} successfully generated.")
 
     @commands.command(aliases=['report', 'rc'])  # Modified from https://gist.github.com/JeffPaine/3145490
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def report_code(self, ctx, game_id: str, code_name: str, issue):
         """Allow reporting a broken code through the bot. Example: .report_code 00040000001B5000, 'PP Not Decrease v1.0', 'PP still decreases with code enabled'"""
         async with self.bot.session.get("https://api.github.com/repos/FlagBrew/Sharkive/contents/3ds") as resp:
@@ -280,7 +281,7 @@ class Utility(commands.Cog):
         await msg.edit(content=f"{prune_amount} users would be kicked as a result of a prune.")
 
     @commands.command()
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def toggledmfaq(self, ctx):
         """Allows a user to toggle getting the faq dm'd to them instead of it posting in channel"""
         if ctx.author.id in self.bot.dm_list:
@@ -381,7 +382,7 @@ class Utility(commands.Cog):
         return hash.hexdigest()
 
     @commands.command(aliases=['scd'])
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def submit_crash_dump(self, ctx, *, description):
         """Allows submitting a PKSM crash dump. Must provide a dump file, and a description. Abusers will be warned."""
         if not ctx.message.attachments or not ctx.message.attachments[0].filename.endswith(".dmp"):
@@ -448,7 +449,7 @@ class Utility(commands.Cog):
         await ctx.send(f"Successfully changed the crash report's status from `{old_embed.fields[4].value}` to `{new_value.title()}`!\nJump link to the edited crash: {message.jump_url}")
 
     @commands.command()
-    @restricted_to_bot
+    @helper.restricted_to_bot
     @commands.has_any_role("FlagBrew Team", "Bot Dev")
     async def clear_hash(self, ctx):
         """Clears the submitted_hashes file"""
@@ -488,7 +489,7 @@ class Utility(commands.Cog):
             await ctx.send(f"{ctx.author.mention} Here's the {lang.lower()} language file:", file=gui_file)
 
     @commands.command(aliases=['ui', 'user'])  # Smth smth stolen from GriffinG1/Midnight but it's *my* license and I do what I want
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def userinfo(self, ctx, user: discord.Member = None, depth=False):
         """Pulls a user's info. Passing no member returns your own. depth is a bool that will specify account creation and join date, and account age"""
         if not user:
@@ -521,7 +522,7 @@ class Utility(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command(aliases=['fui'])  # Fetches discord.User instead of discord.Member
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def fetch_user_info(self, ctx, user: discord.User):
         """Pulls a discord.User instead of discord.Member. More limited than userinfo"""
         embed = discord.Embed(colour=user.colour)
@@ -532,7 +533,7 @@ class Utility(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command(aliases=['si', 'guild', 'gi', 'server', 'serverinfo'])
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def guildinfo(self, ctx, depth=False):
         embed = discord.Embed()
         embed.set_author(name=f"Guild info for {ctx.guild.name} ({ctx.guild.id})", icon_url=str(ctx.guild.icon))
@@ -724,7 +725,7 @@ class Utility(commands.Cog):
         return final_indices
 
     @commands.command()
-    @restricted_to_bot
+    @helper.restricted_to_bot
     async def cheatkeys(self, ctx, *, key):
         """Byte decoder for sharkive codes. Input should be the second half of the line starting with DD000000"""
         key = key.replace(' ', '').replace('DD000000', '')

--- a/addons/utility.py
+++ b/addons/utility.py
@@ -703,6 +703,26 @@ class Utility(commands.Cog):
             embed.set_thumbnail(url=str(invite.guild.icon))
         await ctx.send(embed=embed)
 
+    def get_keys(self, hexval):  # thanks to architdate for the code
+        final_indices = {'3ds': [], 'switch': []}
+        try:
+            decval = int(hexval, 16)
+        except ValueError:
+            return 400
+        while decval != 0:
+            key_index = math.floor(math.log(decval, 2))
+            try:
+                key_3ds = helper.key_inputs.get(hex(2**key_index))[0]
+                if key_3ds != "None":
+                    final_indices['3ds'].append(key_3ds)
+                key_switch = helper.key_inputs.get(hex(2**key_index))[1]
+                if key_switch != "None" and hexval.replace('0x', '')[0] == "8":
+                    final_indices['switch'].append(key_switch)
+            except IndexError:
+                return 400
+            decval -= 2**key_index
+        return final_indices
+
     @commands.command()
     @restricted_to_bot
     async def cheatkeys(self, ctx, *, key):

--- a/addons/utility.py
+++ b/addons/utility.py
@@ -256,7 +256,8 @@ class Utility(commands.Cog):
         issue_body = f"Game ID: {game_id}\nConsole: {console}\nCode name: {code_name}\n\n Issue: {issue}\n\n Submitted by: {ctx.author} | User id: {ctx.author.id}"
         issue = {
             "title": "Broken code submitted through bot",
-            "body": issue_body
+            "body": issue_body,
+            "labels": ['bot submission']
         }
         async with self.bot.session.post(url=url, auth=session_auth, data=json.dumps(issue)) as resp:
             json_content = await resp.json()

--- a/addons/utility.py
+++ b/addons/utility.py
@@ -703,6 +703,23 @@ class Utility(commands.Cog):
             embed.set_thumbnail(url=str(invite.guild.icon))
         await ctx.send(embed=embed)
 
+    @commands.command()
+    @restricted_to_bot
+    async def cheatkeys(self, ctx, *, key):
+        """Byte decoder for sharkive codes. Input should be the second half of the line starting with DD000000"""
+        key = key.replace(' ', '').replace('DD000000', '')
+        if len(key) != 8:
+            return await ctx.send("That isn't a valid key!")
+        indexes = self.get_keys(key)
+        if indexes == 400:
+            return await ctx.send("That isn't a valid key!")
+        embed = discord.Embed(title=f"Matching inputs for `{key}`")
+        if len(indexes["3ds"]) > 0:
+            embed.add_field(name="3DS inputs", value='`' + '` + `'.join(indexes["3ds"]) + '`')
+        if len(indexes["switch"]) > 0:
+            embed.add_field(name="Switch inputs", value='`' + '` + `'.join(indexes["switch"]) + '`', inline=False)
+        await ctx.send(embed=embed)
+
 
 async def setup(bot):
     await bot.add_cog(Utility(bot))

--- a/addons/utility.py
+++ b/addons/utility.py
@@ -729,6 +729,8 @@ class Utility(commands.Cog):
     async def cheatkeys(self, ctx, *, key):
         """Byte decoder for sharkive codes. Input should be the second half of the line starting with DD000000"""
         key = key.replace(' ', '').replace('DD000000', '')
+        if key == "00000000":
+            return await ctx.send("All 0s is a null input combo.")
         if len(key) != 8:
             return await ctx.send("That isn't a valid key!")
         indexes = self.get_keys(key)
@@ -739,6 +741,9 @@ class Utility(commands.Cog):
             embed.add_field(name="3DS inputs", value='`' + '` + `'.join(indexes["3ds"]) + '`')
         if len(indexes["switch"]) > 0:
             embed.add_field(name="Switch inputs", value='`' + '` + `'.join(indexes["switch"]) + '`', inline=False)
+        if len(indexes["3ds"]) == 0 and len(indexes["switch"]) == 0:
+            embed.description = "No inputs could be found for the provided key."
+        await ctx.send(embed=embed)
         await ctx.send(embed=embed)
 
 

--- a/main.py
+++ b/main.py
@@ -83,7 +83,8 @@ intents = discord.Intents().all()
 intents.members = True
 intents.presences = True
 intents.message_content = True
-bot = commands.Bot(command_prefix=prefix, description=description, activity=default_activity, intents=intents)
+help_cmd = commands.DefaultHelpCommand(show_parameter_descriptions=False)
+bot = commands.Bot(command_prefix=prefix, description=description, activity=default_activity, intents=intents, help_command=help_cmd)
 
 if not is_using_cmd_args:  # handles setting up the bot vars
     bot.is_mongodb = config.is_mongodb


### PR DESCRIPTION
- Bot submission label changes may require bot having push permissions, unknown if the account has them
- `.csp` returns formatted Checkpoint save paths for 3ds and Switch games